### PR TITLE
Add CapRover deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ This contains everything you need to run your app locally.
    `npm run server`
 4. Run the app:
    `npm run dev`
+
+## Deploying on CapRover
+
+This repo includes a `captain-definition` file so you can deploy directly to a CapRover server. Build and push your image, or use CapRover's one-click deploy with this repository. The app exposes port `3000` by default.

--- a/captain-definition
+++ b/captain-definition
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 2,
+  "dockerfileLines": [
+    "FROM node:20-alpine",
+    "WORKDIR /usr/src/app",
+    "COPY package*.json ./",
+    "RUN npm install",
+    "COPY . .",
+    "RUN npm run build",
+    "EXPOSE 3000",
+    "CMD [\"npm\", \"run\", \"server\"]"
+  ]
+}


### PR DESCRIPTION
## Summary
- add `captain-definition` for CapRover deployments
- document CapRover deployment steps

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685064300aa483228b2fa2f9f955c097