### PR TITLE
feat: allow public API host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+database.sqlite

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ using a local **SQLite** database so no external database server is required.
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Start the API server (uses SQLite):
+3. (Optional) If the API will run on another host or port, set `VITE_API_BASE`
+   in `.env.local` to its URL (e.g. `http://<ip>:3005/api`).
+4. Start the API server (uses SQLite):
    `PORT=3005 npm run server`
-4. Run the frontend (Vite dev server on port `5173` by default):
+5. Run the frontend (Vite dev server on port `5173` by default):
    `npm run dev`
 
 ### Database

--- a/constants.ts
+++ b/constants.ts
@@ -1,7 +1,8 @@
 import { NavItem, Project, ProjectStatus, ProjectType, TaskStatus, InspectionStatus, InspectionType, PaymentStatus, Client, ProjectPhase, ProjectFile, Task, Payment, Contract, Appointment, PaymentMethod, ProjectSubPhase, KanbanColumn, AppointmentType, User, Lead, LeadStatus, LeadSource, CostItem, ComplexityFactorItem, Inspection, OfficeCostConfigItem, TeamMemberConfigItem, ProjectStage, ProjectStageItem } from './types';
 import { Home, Briefcase, Users, FileText, DollarSign, ListChecks, CalendarDays, Settings, ShieldQuestion, LogOut, CheckSquare, GanttChartSquare, Landmark, SearchCode, Lightbulb, Users2, Building, BarChart3, Copy } from 'lucide-react'; // Added Lightbulb, Users2, Building, BarChart3, Copy
 
-export const API_BASE_URL = '/api'; // Mock API base URL
+// API base URL used by some mock helpers. Can be overridden via `VITE_API_BASE`.
+export const API_BASE_URL = import.meta.env.VITE_API_BASE || '/api';
 
 export const NAVIGATION_ITEMS: NavItem[] = [
   { name: 'Dashboard', href: '/', icon: Home, exact: true },

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,10 @@ import cors from 'cors';
 import db, { initDB } from './database.js';
 
 const app = express();
+// Listen on all network interfaces by default so the API can be reached
+// from the local machine or a remote host.
 const PORT = process.env.PORT || 3001;
+const HOST = process.env.HOST || '0.0.0.0';
 
 initDB();
 app.use(cors());
@@ -78,6 +81,7 @@ app.delete('/api/leads/:id', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(PORT, () => {
-  console.log(`API server running on http://localhost:${PORT}`);
+app.listen(PORT, HOST, () => {
+  const displayHost = HOST === '0.0.0.0' ? 'localhost' : HOST;
+  console.log(`API server running on http://${displayHost}:${PORT}`);
 });

--- a/services/databaseService.ts
+++ b/services/databaseService.ts
@@ -1,7 +1,9 @@
 import { Client, Project, Lead, CostSimulation, OfficeCostConfigItem, TeamMemberConfigItem, User as TeamUser } from '../types';
 import { DEFAULT_OFFICE_COST_CONFIGS_TEMPLATE, DEFAULT_TEAM_MEMBER_CONFIGS_TEMPLATE, MOCK_TEAM_MEMBERS } from '../constants';
 
-const API_BASE = '/api';
+// Allow overriding the API base URL so the frontend can talk to a remote server
+// when running on a different host. Falls back to relative `/api` for local dev.
+const API_BASE = import.meta.env.VITE_API_BASE || '/api';
 
 const fetchJSON = async (url: string, options?: RequestInit) => {
   const res = await fetch(url, options);


### PR DESCRIPTION
## Summary
- support `VITE_API_BASE` so the frontend can call a remote API
- allow the API server to bind on all interfaces
- document the new env var
- ignore generated `database.sqlite`

## Testing
- `npm run build`
- `PORT=3005 node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6861660398448322b18b23437780eb6c