### PR TITLE
Implement missing persistence services

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -57,6 +57,27 @@ export function initDB() {
       createdAt TEXT,
       updatedAt TEXT
     );
+
+    CREATE TABLE IF NOT EXISTS office_cost_configs (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      monthlyBaseValue REAL,
+      isArchived INTEGER DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS team_member_configs (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      role TEXT,
+      hourlyRate REAL,
+      isArchived INTEGER DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS cost_simulations (
+      id TEXT PRIMARY KEY,
+      leadId TEXT,
+      data TEXT
+    );
   `);
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,10 @@ const updateRecord = (table, id, record) => {
 const deleteRecord = (table, id) => {
   db.prepare(`DELETE FROM ${table} WHERE id=?`).run(id);
 };
+const getActive = (table) => db.prepare(`SELECT * FROM ${table} WHERE isArchived IS NULL OR isArchived=0`).all();
+const archiveRecord = (table, id) => {
+  db.prepare(`UPDATE ${table} SET isArchived=1 WHERE id=?`).run(id);
+};
 
 // Clients endpoints
 app.get('/api/clients', (req, res) => {
@@ -78,6 +82,55 @@ app.put('/api/leads/:id', (req, res) => {
 });
 app.delete('/api/leads/:id', (req, res) => {
   deleteRecord('leads', req.params.id);
+  res.json({ status: 'ok' });
+});
+
+// Office cost configs endpoints
+app.get('/api/office_cost_configs', (req, res) => {
+  res.json(getActive('office_cost_configs'));
+});
+app.post('/api/office_cost_configs', (req, res) => {
+  insertRecord('office_cost_configs', req.body);
+  res.json({ status: 'ok' });
+});
+app.put('/api/office_cost_configs/:id', (req, res) => {
+  updateRecord('office_cost_configs', req.params.id, req.body);
+  res.json({ status: 'ok' });
+});
+app.delete('/api/office_cost_configs/:id', (req, res) => {
+  archiveRecord('office_cost_configs', req.params.id);
+  res.json({ status: 'ok' });
+});
+
+// Team member configs endpoints
+app.get('/api/team_member_configs', (req, res) => {
+  res.json(getActive('team_member_configs'));
+});
+app.post('/api/team_member_configs', (req, res) => {
+  insertRecord('team_member_configs', req.body);
+  res.json({ status: 'ok' });
+});
+app.put('/api/team_member_configs/:id', (req, res) => {
+  updateRecord('team_member_configs', req.params.id, req.body);
+  res.json({ status: 'ok' });
+});
+app.delete('/api/team_member_configs/:id', (req, res) => {
+  archiveRecord('team_member_configs', req.params.id);
+  res.json({ status: 'ok' });
+});
+
+// Cost simulations endpoints
+app.get('/api/cost_simulations', (req, res) => {
+  const rows = db.prepare('SELECT * FROM cost_simulations').all();
+  const sims = rows.map(r => ({ id: r.id, leadId: r.leadId, ...JSON.parse(r.data) }));
+  res.json(sims);
+});
+app.post('/api/cost_simulations', (req, res) => {
+  insertRecord('cost_simulations', { id: req.body.id, leadId: req.body.leadId, data: JSON.stringify(req.body) });
+  res.json({ status: 'ok' });
+});
+app.put('/api/cost_simulations/:id', (req, res) => {
+  updateRecord('cost_simulations', req.params.id, { leadId: req.body.leadId, data: JSON.stringify(req.body) });
   res.json({ status: 'ok' });
 });
 

--- a/services/databaseService.ts
+++ b/services/databaseService.ts
@@ -14,6 +14,11 @@ const fetchJSON = async (url: string, options?: RequestInit) => {
   return res.json();
 };
 
+const recordExists = async (endpoint: string, id: string): Promise<boolean> => {
+  const items: any[] = await fetchJSON(`${API_BASE}/${endpoint}`);
+  return items.some(i => i.id === id);
+};
+
 // --- Client CRUD ---
 export const getClients = async (): Promise<Client[]> => fetchJSON(`${API_BASE}/clients`);
 export const addClient = async (client: Client): Promise<void> => {
@@ -51,18 +56,57 @@ export const deleteLead = async (leadId: string): Promise<void> => {
 };
 
 // --- CostSimulation CRUD (placeholders) ---
-export const getCostSimulations = async (): Promise<CostSimulation[]> => [];
-export const addOrUpdateCostSimulation = async (_sim: CostSimulation): Promise<void> => { /* not implemented */ };
+export const getCostSimulations = async (): Promise<CostSimulation[]> =>
+  fetchJSON(`${API_BASE}/cost_simulations`);
+
+export const addOrUpdateCostSimulation = async (sim: CostSimulation): Promise<void> => {
+  const exists = await recordExists('cost_simulations', sim.id);
+  const url = exists ? `${API_BASE}/cost_simulations/${sim.id}` : `${API_BASE}/cost_simulations`;
+  const method = exists ? 'PUT' : 'POST';
+  await fetchJSON(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(sim)
+  });
+};
 
 // --- OfficeCostConfig CRUD (uses constants for now) ---
-export const getOfficeCostConfigs = async (): Promise<OfficeCostConfigItem[]> => DEFAULT_OFFICE_COST_CONFIGS_TEMPLATE;
-export const addOrUpdateOfficeCostConfig = async (_config: OfficeCostConfigItem): Promise<void> => { /* not implemented */ };
-export const deleteOfficeCostConfig = async (_id: string): Promise<void> => { /* not implemented */ };
+export const getOfficeCostConfigs = async (): Promise<OfficeCostConfigItem[]> =>
+  fetchJSON(`${API_BASE}/office_cost_configs`);
+
+export const addOrUpdateOfficeCostConfig = async (config: OfficeCostConfigItem): Promise<void> => {
+  const exists = await recordExists('office_cost_configs', config.id);
+  const url = exists ? `${API_BASE}/office_cost_configs/${config.id}` : `${API_BASE}/office_cost_configs`;
+  const method = exists ? 'PUT' : 'POST';
+  await fetchJSON(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(config)
+  });
+};
+
+export const deleteOfficeCostConfig = async (id: string): Promise<void> => {
+  await fetchJSON(`${API_BASE}/office_cost_configs/${id}`, { method: 'DELETE' });
+};
 
 // --- TeamMemberConfig CRUD (uses constants for now) ---
-export const getTeamMemberConfigs = async (): Promise<TeamMemberConfigItem[]> => DEFAULT_TEAM_MEMBER_CONFIGS_TEMPLATE;
-export const addOrUpdateTeamMemberConfig = async (_config: TeamMemberConfigItem): Promise<void> => { /* not implemented */ };
-export const deleteTeamMemberConfig = async (_id: string): Promise<void> => { /* not implemented */ };
+export const getTeamMemberConfigs = async (): Promise<TeamMemberConfigItem[]> =>
+  fetchJSON(`${API_BASE}/team_member_configs`);
+
+export const addOrUpdateTeamMemberConfig = async (config: TeamMemberConfigItem): Promise<void> => {
+  const exists = await recordExists('team_member_configs', config.id);
+  const url = exists ? `${API_BASE}/team_member_configs/${config.id}` : `${API_BASE}/team_member_configs`;
+  const method = exists ? 'PUT' : 'POST';
+  await fetchJSON(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(config)
+  });
+};
+
+export const deleteTeamMemberConfig = async (id: string): Promise<void> => {
+  await fetchJSON(`${API_BASE}/team_member_configs/${id}`, { method: 'DELETE' });
+};
 
 // --- TeamUser CRUD ---
 export const getTeamUsers = async (): Promise<TeamUser[]> => MOCK_TEAM_MEMBERS;


### PR DESCRIPTION
## Summary
- add missing tables for settings and cost simulations
- implement API routes for settings and simulation data
- connect databaseService to new API endpoints

## Testing
- `npm run build`
- `node server/index.js` (manual server start)

------
https://chatgpt.com/codex/tasks/task_e_686187e36d808322b56c1dd31a87b85b