### PR TITLE
Seed demo admin user in SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ project root. You can inspect or modify this file with any SQLite tool, e.g.:
 sqlite3 database.sqlite
 ```
 
+The database is initialized with a demo administrator account using the
+credentials `demo@dev.com` / `demopass`. You can log in with these credentials
+or modify the `server/database.js` file to seed a different user.
+
 ## Running with PM2
 
 Install [PM2](https://pm2.keymetrics.io) globally:

--- a/server/database.js
+++ b/server/database.js
@@ -78,7 +78,33 @@ export function initDB() {
       leadId TEXT,
       data TEXT
     );
+
+    CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      email TEXT UNIQUE,
+      password TEXT,
+      role TEXT,
+      avatarUrl TEXT,
+      hourlyRate REAL
+    );
   `);
+
+  // Seed demo admin user if it doesn't exist
+  const count = db
+    .prepare('SELECT COUNT(*) as count FROM users WHERE email = ?')
+    .get('demo@dev.com').count;
+  if (count === 0) {
+    db.prepare(
+      'INSERT INTO users (id, name, email, password, role) VALUES (@id, @name, @email, @password, @role)'
+    ).run({
+      id: 'user-admin',
+      name: 'Demo Admin',
+      email: 'demo@dev.com',
+      password: 'demopass',
+      role: 'admin'
+    });
+  }
 }
 
 export default db;


### PR DESCRIPTION
## Summary
- initialize a `users` table in the server's SQLite DB
- seed the table with a demo admin user
- document the seeded account in the README

## Testing
- `npm run server`

------
https://chatgpt.com/codex/tasks/task_e_686189a0ea4c8322851f9bc2f280c5ff