### PR TITLE
Fix backend SQLite persistence

### DIFF
--- a/server/dataAccess.js
+++ b/server/dataAccess.js
@@ -1,0 +1,102 @@
+import db from './database.js';
+import { DEFAULT_OFFICE_COST_CONFIGS_TEMPLATE, DEFAULT_TEAM_MEMBER_CONFIGS_TEMPLATE } from './defaults.js';
+
+const ACTIVE_CLAUSE = 'isArchived IS NULL OR isArchived = 0';
+
+// --- Helper to insert multiple rows in a transaction ---
+function insertMany(table, items, columns) {
+  const cols = columns || Object.keys(items[0]);
+  const placeholders = cols.map(() => '?').join(',');
+  const stmt = db.prepare(`INSERT INTO ${table} (${cols.join(',')}) VALUES (${placeholders})`);
+  const run = db.transaction((records) => {
+    for (const r of records) {
+      stmt.run(...cols.map(c => r[c]));
+    }
+  });
+  run(items);
+}
+
+// --- Office Cost Configs ---
+export function getAllOfficeCostConfigs() {
+  let rows = db.prepare(`SELECT * FROM office_cost_configs WHERE ${ACTIVE_CLAUSE}`).all();
+  if (rows.length === 0) {
+    insertMany('office_cost_configs', DEFAULT_OFFICE_COST_CONFIGS_TEMPLATE, ['id','name','monthlyBaseValue','isArchived']);
+    rows = db.prepare(`SELECT * FROM office_cost_configs WHERE ${ACTIVE_CLAUSE}`).all();
+  }
+  return rows;
+}
+
+export function addOrUpdateOfficeCostConfig(item) {
+  const exists = db.prepare('SELECT COUNT(*) as count FROM office_cost_configs WHERE id=?').get(item.id).count > 0;
+  if (exists) {
+    db.prepare('UPDATE office_cost_configs SET name=@name, monthlyBaseValue=@monthlyBaseValue WHERE id=@id').run(item);
+  } else {
+    insertMany('office_cost_configs', [{...item, isArchived:0}], ['id','name','monthlyBaseValue','isArchived']);
+  }
+}
+
+export function deleteOfficeCostConfig(id) {
+  db.prepare('UPDATE office_cost_configs SET isArchived=1 WHERE id=?').run(id);
+}
+
+// --- Team Member Configs ---
+export function getAllTeamMemberConfigs() {
+  let rows = db.prepare(`SELECT * FROM team_member_configs WHERE ${ACTIVE_CLAUSE}`).all();
+  if (rows.length === 0) {
+    insertMany('team_member_configs', DEFAULT_TEAM_MEMBER_CONFIGS_TEMPLATE.map(i => ({...i,isArchived:0})), ['id','name','role','hourlyRate','isArchived']);
+    rows = db.prepare(`SELECT * FROM team_member_configs WHERE ${ACTIVE_CLAUSE}`).all();
+  }
+  return rows;
+}
+
+export function addOrUpdateTeamMemberConfig(item) {
+  const exists = db.prepare('SELECT COUNT(*) as count FROM team_member_configs WHERE id=?').get(item.id).count > 0;
+  if (exists) {
+    db.prepare('UPDATE team_member_configs SET name=@name, role=@role, hourlyRate=@hourlyRate WHERE id=@id').run(item);
+  } else {
+    insertMany('team_member_configs', [{...item,isArchived:0}], ['id','name','role','hourlyRate','isArchived']);
+  }
+}
+
+export function deleteTeamMemberConfig(id) {
+  db.prepare('UPDATE team_member_configs SET isArchived=1 WHERE id=?').run(id);
+}
+
+// --- Users (Team Members) ---
+export function getAllUsers() {
+  return db.prepare(`SELECT id, name, email, role, hourlyRate FROM users WHERE ${ACTIVE_CLAUSE}`).all();
+}
+
+export function addOrUpdateUser(user) {
+  const exists = db.prepare('SELECT COUNT(*) as count FROM users WHERE id=?').get(user.id).count > 0;
+  const data = { id:user.id, name:user.name, email:user.email, role:user.role, hourlyRate:user.hourlyRate };
+  if (exists) {
+    db.prepare('UPDATE users SET name=@name, email=@email, role=@role, hourlyRate=@hourlyRate WHERE id=@id').run(data);
+  } else {
+    insertMany('users', [{...data,isArchived:0}], ['id','name','email','role','hourlyRate','isArchived']);
+  }
+}
+
+export function deleteUser(id) {
+  db.prepare('UPDATE users SET isArchived=1 WHERE id=?').run(id);
+}
+
+// --- Cost Simulations ---
+export function getAllCostSimulations() {
+  const rows = db.prepare(`SELECT id, leadId, data FROM cost_simulations WHERE ${ACTIVE_CLAUSE}`).all();
+  return rows.map(r => ({ id: r.id, leadId: r.leadId, ...JSON.parse(r.data) }));
+}
+
+export function addOrUpdateCostSimulation(sim) {
+  const exists = db.prepare('SELECT COUNT(*) as count FROM cost_simulations WHERE id=?').get(sim.id).count > 0;
+  const record = { id: sim.id, leadId: sim.leadId, data: JSON.stringify(sim) };
+  if (exists) {
+    db.prepare('UPDATE cost_simulations SET leadId=@leadId, data=@data WHERE id=@id').run(record);
+  } else {
+    insertMany('cost_simulations', [{...record, isArchived:0}], ['id','leadId','data','isArchived']);
+  }
+}
+
+export function deleteCostSimulation(id) {
+  db.prepare('UPDATE cost_simulations SET isArchived=1 WHERE id=?').run(id);
+}

--- a/server/database.js
+++ b/server/database.js
@@ -76,7 +76,8 @@ export function initDB() {
     CREATE TABLE IF NOT EXISTS cost_simulations (
       id TEXT PRIMARY KEY,
       leadId TEXT,
-      data TEXT
+      data TEXT,
+      isArchived INTEGER DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS users (
@@ -86,7 +87,8 @@ export function initDB() {
       password TEXT,
       role TEXT,
       avatarUrl TEXT,
-      hourlyRate REAL
+      hourlyRate REAL,
+      isArchived INTEGER DEFAULT 0
     );
   `);
 

--- a/server/defaults.js
+++ b/server/defaults.js
@@ -1,0 +1,28 @@
+export const DEFAULT_OFFICE_COST_CONFIGS_TEMPLATE = [
+  { id: 'config-fixed-aluguel', name: 'Aluguel/Prestação Escritório', monthlyBaseValue: 1600 },
+  { id: 'config-fixed-condominio', name: 'Condomínio Escritório', monthlyBaseValue: 400 },
+  { id: 'config-fixed-seguro', name: 'Seguro Escritório', monthlyBaseValue: 100 },
+  { id: 'config-fixed-iptu', name: 'IPTU Escritório', monthlyBaseValue: 100 },
+  { id: 'config-fixed-luz', name: 'Luz', monthlyBaseValue: 120 },
+  { id: 'config-fixed-internet', name: 'Internet', monthlyBaseValue: 100 },
+  { id: 'config-fixed-agua', name: 'Água', monthlyBaseValue: 60 },
+  { id: 'config-fixed-contador', name: 'Contador', monthlyBaseValue: 150 },
+  { id: 'config-fixed-faxina', name: 'Faxina', monthlyBaseValue: 200 },
+  { id: 'config-fixed-compras', name: 'Compras (café, material limpeza)', monthlyBaseValue: 300 },
+  { id: 'config-fixed-assinaturas', name: 'Assinaturas (software, etc)', monthlyBaseValue: 80 },
+  { id: 'config-fixed-software-lic', name: 'Softwares/Licenças (valor mensalizado)', monthlyBaseValue: 400 },
+  { id: 'config-fixed-social-media', name: 'Social Media', monthlyBaseValue: 1000 },
+  { id: 'config-fixed-gestor-trafego', name: 'Gestor de Tráfego', monthlyBaseValue: 1300 },
+  { id: 'config-fixed-trafego-anuncios', name: 'Tráfego/Anúncios', monthlyBaseValue: 1000 },
+  { id: 'config-fixed-gasolina-geral', name: 'Gasolina (geral escritório)', monthlyBaseValue: 400 },
+];
+
+export const DEFAULT_TEAM_MEMBER_CONFIGS_TEMPLATE = [
+  { id: 'user-clarissa', name: 'Clarissa Dario', role: 'Arquiteta Principal', hourlyRate: 150 },
+  { id: 'user-socio1', name: 'Sócio 01 (Ana)', role: 'Sócio Arquiteto', hourlyRate: 97.22 },
+  { id: 'user-socio2', name: 'Sócio 02 (Bruno)', role: 'Sócio Administrador', hourlyRate: 97.22 },
+  { id: 'user-arqjunior', name: 'Arq. Júnior (Carlos)', role: 'Arquiteto Júnior', hourlyRate: 25.52 },
+  { id: 'user-estagiario1', name: 'Estagiário 01 (Diana)', role: 'Estagiário de Arquitetura', hourlyRate: 9.33 },
+  { id: 'user-estagiario2', name: 'Estagiário 02 (Eduardo)', role: 'Estagiário de Design', hourlyRate: 9.33 },
+  { id: 'por-elas', name: 'Por Elas (Terceirizado)', role: 'Serviços Terceirizados', hourlyRate: 35.00 },
+];

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,20 @@
 import express from 'express';
 import cors from 'cors';
 import db, { initDB } from './database.js';
+import {
+  getAllOfficeCostConfigs,
+  addOrUpdateOfficeCostConfig,
+  deleteOfficeCostConfig,
+  getAllTeamMemberConfigs,
+  addOrUpdateTeamMemberConfig,
+  deleteTeamMemberConfig,
+  getAllUsers,
+  addOrUpdateUser,
+  deleteUser,
+  getAllCostSimulations,
+  addOrUpdateCostSimulation,
+  deleteCostSimulation
+} from './dataAccess.js';
 
 const app = express();
 // Listen on all network interfaces by default so the API can be reached
@@ -9,6 +23,11 @@ const PORT = process.env.PORT || 3001;
 const HOST = process.env.HOST || '0.0.0.0';
 
 initDB();
+const initialOffice = getAllOfficeCostConfigs().length;
+const initialTeamCfg = getAllTeamMemberConfigs().length;
+const initialUsers = getAllUsers().length;
+const initialSims = getAllCostSimulations().length;
+console.log(`Loaded ${initialOffice} office configs, ${initialTeamCfg} team member configs, ${initialUsers} users, ${initialSims} cost simulations`);
 app.use(cors());
 app.use(express.json());
 
@@ -87,51 +106,150 @@ app.delete('/api/leads/:id', (req, res) => {
 
 // Office cost configs endpoints
 app.get('/api/office_cost_configs', (req, res) => {
-  res.json(getActive('office_cost_configs'));
+  try {
+    res.json(getAllOfficeCostConfigs());
+  } catch (err) {
+    console.error('Failed to load office cost configs', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 app.post('/api/office_cost_configs', (req, res) => {
-  insertRecord('office_cost_configs', req.body);
-  res.json({ status: 'ok' });
+  try {
+    addOrUpdateOfficeCostConfig(req.body);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to save office cost config', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 app.put('/api/office_cost_configs/:id', (req, res) => {
-  updateRecord('office_cost_configs', req.params.id, req.body);
-  res.json({ status: 'ok' });
+  try {
+    addOrUpdateOfficeCostConfig({ ...req.body, id: req.params.id });
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to update office cost config', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 app.delete('/api/office_cost_configs/:id', (req, res) => {
-  archiveRecord('office_cost_configs', req.params.id);
-  res.json({ status: 'ok' });
+  try {
+    deleteOfficeCostConfig(req.params.id);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to delete office cost config', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 
 // Team member configs endpoints
 app.get('/api/team_member_configs', (req, res) => {
-  res.json(getActive('team_member_configs'));
+  try {
+    res.json(getAllTeamMemberConfigs());
+  } catch (err) {
+    console.error('Failed to load team member configs', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 app.post('/api/team_member_configs', (req, res) => {
-  insertRecord('team_member_configs', req.body);
-  res.json({ status: 'ok' });
+  try {
+    addOrUpdateTeamMemberConfig(req.body);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to save team member config', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 app.put('/api/team_member_configs/:id', (req, res) => {
-  updateRecord('team_member_configs', req.params.id, req.body);
-  res.json({ status: 'ok' });
+  try {
+    addOrUpdateTeamMemberConfig({ ...req.body, id: req.params.id });
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to update team member config', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 app.delete('/api/team_member_configs/:id', (req, res) => {
-  archiveRecord('team_member_configs', req.params.id);
-  res.json({ status: 'ok' });
+  try {
+    deleteTeamMemberConfig(req.params.id);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to delete team member config', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// Users (team members) endpoints
+app.get('/api/team-members', (req, res) => {
+  try {
+    res.json(getAllUsers());
+  } catch (err) {
+    console.error('Failed to load users', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+app.post('/api/team-members', (req, res) => {
+  try {
+    addOrUpdateUser(req.body);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to save user', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+app.put('/api/team-members/:id', (req, res) => {
+  try {
+    addOrUpdateUser({ ...req.body, id: req.params.id });
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to update user', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+app.delete('/api/team-members/:id', (req, res) => {
+  try {
+    deleteUser(req.params.id);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to delete user', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 
 // Cost simulations endpoints
 app.get('/api/cost_simulations', (req, res) => {
-  const rows = db.prepare('SELECT * FROM cost_simulations').all();
-  const sims = rows.map(r => ({ id: r.id, leadId: r.leadId, ...JSON.parse(r.data) }));
-  res.json(sims);
+  try {
+    res.json(getAllCostSimulations());
+  } catch (err) {
+    console.error('Failed to load cost simulations', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 app.post('/api/cost_simulations', (req, res) => {
-  insertRecord('cost_simulations', { id: req.body.id, leadId: req.body.leadId, data: JSON.stringify(req.body) });
-  res.json({ status: 'ok' });
+  try {
+    addOrUpdateCostSimulation(req.body);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to save cost simulation', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 app.put('/api/cost_simulations/:id', (req, res) => {
-  updateRecord('cost_simulations', req.params.id, { leadId: req.body.leadId, data: JSON.stringify(req.body) });
-  res.json({ status: 'ok' });
+  try {
+    addOrUpdateCostSimulation({ ...req.body, id: req.params.id });
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to update cost simulation', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+app.delete('/api/cost_simulations/:id', (req, res) => {
+  try {
+    deleteCostSimulation(req.params.id);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error('Failed to delete cost simulation', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 
 app.listen(PORT, HOST, () => {

--- a/services/databaseService.ts
+++ b/services/databaseService.ts
@@ -109,7 +109,20 @@ export const deleteTeamMemberConfig = async (id: string): Promise<void> => {
 };
 
 // --- TeamUser CRUD ---
-export const getTeamUsers = async (): Promise<TeamUser[]> => MOCK_TEAM_MEMBERS;
-export const addOrUpdateTeamUser = async (_user: TeamUser): Promise<void> => { /* not implemented */ };
+export const getTeamUsers = async (): Promise<TeamUser[]> =>
+  fetchJSON(`${API_BASE}/team-members`);
+
+export const addOrUpdateTeamUser = async (user: TeamUser): Promise<void> => {
+  const exists = await recordExists('team-members', user.id);
+  const url = exists
+    ? `${API_BASE}/team-members/${user.id}`
+    : `${API_BASE}/team-members`;
+  const method = exists ? 'PUT' : 'POST';
+  await fetchJSON(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(user)
+  });
+};
 
 export const initDB = async (): Promise<boolean> => true;


### PR DESCRIPTION
## Summary
- persist records in SQLite using new data access layer
- seed tables with default configs when empty
- expose CRUD APIs for office costs, team members, users and cost simulations
- connect frontend database service to new `/team-members` API
- log number of loaded records when server starts

## Testing
- `npm run build`
- `npm run server` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_e_68618c697ae0832285b2a00a3717fa23